### PR TITLE
Fix plugin initialization

### DIFF
--- a/plugin/flare.vim
+++ b/plugin/flare.vim
@@ -1,1 +1,2 @@
-lua myluamodule = require("flare").setup({})
+" Automatically start flare.nvim when the plugin loads
+lua require("flare").setup({})


### PR DESCRIPTION
## Summary
- avoid polluting globals when calling setup

## Testing
- `make test` *(fails: `nvim` not found)*